### PR TITLE
[SIS-127] Display featured activity cards upon very first render/boot-up

### DIFF
--- a/src/home/screens/Home.js
+++ b/src/home/screens/Home.js
@@ -31,7 +31,7 @@ const Home = ({ navigation }) => {
     const filePath = `${datePath}/date.txt`;
     const cards = await ActivityCardService.getFeaturedActivityCards();
 
-    //update the last refreshed date
+    //update the last refreshed date and card array if new cards were found
     if (cards.length != 0) {
       setPathArr(cards);
 
@@ -66,7 +66,11 @@ const Home = ({ navigation }) => {
           if (tempArr.length != 0) {
             setPathArr(tempArr);
           }
+        }else{
+          //very first time loading the app, no cards in RNFS
+          handleRefreshPress();
         }
+
       } catch (error) {
         console.error(error);
       }

--- a/src/services/ActivityCardService.js
+++ b/src/services/ActivityCardService.js
@@ -51,16 +51,17 @@ const ActivityCardService = {
       const files_list = driveFiles.files;
       var pathArr = [];
 
+      //no new files found, return an empty array (old Activity Cards are mapped onto frontend)
       if (files_list.length == 0) {
         return [];
       }
 
-      //Delete anything that may currently be in the Featured Cards directory, make the new path with no contents
-      if (files_list.length !== 0) {
+      //Delete anything that may currently be in the Featured Cards directory, make the new path with no content
+      if (await checkFileExists(path)) {
         await deleteFile(path);
         await makeDirectory(path);
-      } else {
-        return;
+      }else{
+        await makeDirectory(path);
       }
 
       //if new cards were found, save them into the empty directory path


### PR DESCRIPTION
get featuredActivityCards on very first load. Bug fixes to getFeaturedActivityCards

# Description

call getFeaturedActivityCards when app is loaded for the very first time (when directory DNE). Removed warnings for getFeaturedActivityCards

Ticket #

[SIS-027](https://github.com/uoftblueprint/sistema/issues/127)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My PR title is formatted as [SIS-\<issue number\>] \<issue name\> (eg. [SIS-010] Create UI button)
- [x] I have linked my issue/ticket on the project board to this PR
- [x] I have sent my PR to #team-sistema-prs on Slack and requested two people to review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if required)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
