### PR TITLE
[SIS-042] More network error handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ axios.interceptors.response.use(
   },
   error => {
     // If 4xx client error, purposefully set an invalid token to trigger token refresh on next request
-    if (error?.response?.status >= 400  && error?.response?.status < 500) {
+    if (error?.response?.status >= 400 && error?.response?.status < 500) {
       console.warn("Reseting token to refresh on next HTTP request due to 4xx client error.");
       invalidToken = new AccessToken(); // default has automatically invalid expiry time
       store.dispatch(setNewToken(invalidToken)); // set invalid token to redux (isTokenValid checks redux)


### PR DESCRIPTION
# Description

If axios intercepts a 4xx client error after it has occurred, purposefully set an invalid token to trigger token refresh on next request. Added to specifically handle 429 Too Many Requests since there is a max number of tokens that can exist at once (creating a new valid token simply disables the oldest used one). I doubt we'll hit this but error handling just in case right *shrug* 

User will hopefully be prompted with an error message to "Try again", and on next HTTP request, will trigger a token refresh and then resolve the issue. Unless it's actually a badly malformed body in the HTTP request in which case there's no helping.

Ticket # 042

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My PR title is formatted as [SIS-\<issue number\>] \<issue name\> (eg. [SIS-010] Create UI button)
- [] I have linked my issue/ticket on the project board to this PR
- [ ] I have sent my PR to #team-sistema-prs on Slack and requested two people to review
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if required)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
