### PR TITLE
[SIS-FIX] Quick fixes: pdf export linking, dark mode text on Android

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
         <item name="android:forceDarkAllowed">false</item>

--- a/src/editor/components/DraggableModuleWithMenu.js
+++ b/src/editor/components/DraggableModuleWithMenu.js
@@ -19,7 +19,6 @@ import { TextStyle } from '../../Styles.config';
 import LinkIcon from '../../../assets/linkIcon.svg';
 
 import { scale, verticalScale } from 'react-native-size-matters';
-import { Link } from '@react-navigation/native';
 
 // Modified from https://github.com/izzisolomon/react-native-options-menu to handle onLongPress and to suit our needs
 

--- a/src/library/components/SortingButton.js
+++ b/src/library/components/SortingButton.js
@@ -13,7 +13,7 @@ const SortingButton = ({ text, onPress }) => {
       <TouchableOpacity
         style={[TextStyle.label, styles.buttonContainer]}
         onPress={onPress}>
-        <Text style={styles.textContainer}>{text}</Text>
+        <Text style={[TextStyle.body, styles.textContainer]}>{text}</Text>
       </TouchableOpacity>
     </SafeAreaView>
   );

--- a/src/services/pdf.js
+++ b/src/services/pdf.js
@@ -1,4 +1,5 @@
 import RNHTMLtoPDF from 'react-native-html-to-pdf';
+import { ModuleType } from './constants';
 
 /**
  * creates a pdf for a given lesson plan
@@ -44,8 +45,18 @@ const moduleInformation = (module, moduleName) => {
     ret.push(header(moduleName, 2));
   }
   module.forEach(element => {
-    if (element.type === 'text') {
+    if (element.type === ModuleType.text) {
       ret.push(paragraph(element.content));
+    } else if (element.type === ModuleType.link) {
+      // Clean the link first
+      cleanLink = element.content;
+      if (cleanLink.search(/^http[s]?\:\/\//) == -1) {
+        cleanLink = 'http://' + cleanLink;
+      }
+      
+      ret.push(
+        `<p>Link: ${element.title} <a href="${cleanLink}">${cleanLink}</a></p>`,
+      );
     } else {
       ret.push(
         `<img src="file://${element.content}" style="height:600;float:center;border:0px"/><br>`,


### PR DESCRIPTION
# Description

The following is fixed in this PR:

- [x] Link module types in .pdf export (both Android and iOS is working)
- [x] Text becoming white (unreadable) in library sort menu when Android phone is on dark mode

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My PR title is formatted as [SIS-\<issue number\>] \<issue name\> (eg. [SIS-010] Create UI button)
- [ ] I have linked my issue/ticket on the project board to this PR
- [ ] I have sent my PR to #team-sistema-prs on Slack and requested two people to review
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (if required)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
