### PR TITLE
[SIS-FIX] expanded touchable area of library buttons

### DIFF
--- a/src/library/components/LessonPlanButton.js
+++ b/src/library/components/LessonPlanButton.js
@@ -69,7 +69,7 @@ const styles = StyleSheet.create({
     margin: 14,
   },
   titleContainer: {
-    width: '60%',
+    flex: 1, 
     padding: 14,
   },
   heart: {


### PR DESCRIPTION
# Description

Wot it says on the tinnnnnn, made TouchableOpacity a bit bigger and easier to press for the lesson plan buttons in the library!

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

