### PR TITLE
[SIS-141] Fixed lesson plan export image display from library

### DIFF
--- a/src/Components/OptionsMenu.js
+++ b/src/Components/OptionsMenu.js
@@ -17,6 +17,7 @@ import {
   setFavState,
   getCurrFavState,
 } from '../services/editor/lessonPlanSlice.js';
+import { MAINDIRECTORY, ModuleType } from '../services/constants.js';
 
 const OptionsMenu = ({
   isLessonPlanEditor,
@@ -81,7 +82,23 @@ const OptionsMenu = ({
     const lpObj = isLessonPlanEditor
       ? lessonPlan // get lesson plan from redux since we're in the editor already
       : await LessonPlanService.getLessonPlan(lessonPlanName);
+
+    const pathPrefix = isCurrentlyFavorited 
+      ? MAINDIRECTORY + '/Favourited/' + lessonPlanName
+      : MAINDIRECTORY + '/Default/' + lessonPlanName;
+
+    // Add in full path (not just relative path) for the images and ACs
+    for (const [key, value] of Object.entries(lpObj)) {
+      for (i = 0; i < value.length; i++) {
+        if (value[i].type === ModuleType.activityCard
+          || value[i].type === ModuleType.image) {
+            lpObj[key][i].path = pathPrefix + lpObj[key][i].content;
+        }
+      }
+    }
+
     let pdf = await createPDF(lpObj);
+
     try {
       await Share.open({
         url: 'file://' + pdf.filePath,


### PR DESCRIPTION
# Description

Exporting was bugged from the library after we switched to using relative paths in the lesson plan objects in the RNFS .jsons, so I added some logic to make the paths absolute prior to exporting

Ticket #141 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My PR title is formatted as [SIS-\<issue number\>] \<issue name\> (eg. [SIS-010] Create UI button)
- [ ] I have linked my issue/ticket on the project board to this PR
- [ ] I have sent my PR to #team-sistema-prs on Slack and requested two people to review
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if required)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
